### PR TITLE
exit span background when its parent process changes

### DIFF
--- a/demos/10-span-background-simple.sh
+++ b/demos/10-span-background-simple.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# an otel-cli demo of span background
+
+../otel-cli span background \
+    --service $0 \
+    --name "executing $0" \
+    --timeout 2 &
+#               ^ run otel-cli in the background
+sleep 1
+
+# that's it, that's the demo
+# when this script exits, otel-cli will exit too so total runtime will
+# be a bit over 1 second


### PR DESCRIPTION
This enables `otel-cli span background` to exit automatically when its parent process exits so a simple use case is to just run a span in the background and forget about it to wrap a span around a script easily.