### PR TITLE
use the newer loadTraceparent helper

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -43,7 +43,7 @@ func init() {
 func doExec(cmd *cobra.Command, args []string) {
 	ctx, shutdown := initTracer()
 	defer shutdown()
-	ctx = loadTraceparentFromEnv(ctx)
+	ctx = loadTraceparent(ctx, traceparentCarrierFile)
 	tracer := otel.Tracer("otel-cli/exec")
 
 	// joining the string here is kinda gross... but should be fine


### PR DESCRIPTION
I forgot to update this call site when I added loadTraceparent()
on top of loadTraceparentFromEnv and the file support.