### PR TITLE
add tests for otelclicarrier.go and helpers.go

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -86,5 +86,5 @@ func doExec(cmd *cobra.Command, args []string) {
 	// set the global exit code so main() can grab it and os.Exit() properly
 	exitCode = child.ProcessState.ExitCode()
 
-	finishOtelCliSpan(ctx, span)
+	finishOtelCliSpan(ctx, span, os.Stdout)
 }

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1,0 +1,201 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestCliAttrsToOtel(t *testing.T) {
+
+	testAttrs := map[string]string{
+		"test 1 - string":      "isn't testing fun?",
+		"test 2 - int64":       "111111111",
+		"test 3 - float":       "2.4391111",
+		"test 4 - bool, true":  "true",
+		"test 5 - bool, false": "false",
+		"test 6 - bool, True":  "True",
+		"test 7 - bool, False": "False",
+	}
+
+	otelAttrs := cliAttrsToOtel(testAttrs)
+
+	// can't count on any ordering from map -> array
+	for _, attr := range otelAttrs {
+		key := string(attr.Key)
+		switch key {
+		case "test 1 - string":
+			if attr.Value.AsString() != testAttrs[key] {
+				t.Errorf("expected value '%s' for key '%s' but got '%s'", testAttrs[key], key, attr.Value.AsString())
+			}
+		case "test 2 - int64":
+			if attr.Value.AsInt64() != 111111111 {
+				t.Errorf("expected value '%s' for key '%s' but got %d", testAttrs[key], key, attr.Value.AsInt64())
+			}
+		case "test 3 - float":
+			if attr.Value.AsFloat64() != 2.4391111 {
+				t.Errorf("expected value '%s' for key '%s' but got %f", testAttrs[key], key, attr.Value.AsFloat64())
+			}
+		case "test 4 - bool, true":
+			if attr.Value.AsBool() != true {
+				t.Errorf("expected value '%s' for key '%s' but got %t", testAttrs[key], key, attr.Value.AsBool())
+			}
+		case "test 5 - bool, false":
+			if attr.Value.AsBool() != false {
+				t.Errorf("expected value '%s' for key '%s' but got %t", testAttrs[key], key, attr.Value.AsBool())
+			}
+		case "test 6 - bool, True":
+			if attr.Value.AsBool() != true {
+				t.Errorf("expected value '%s' for key '%s' but got %t", testAttrs[key], key, attr.Value.AsBool())
+			}
+		case "test 7 - bool, False":
+			if attr.Value.AsBool() != false {
+				t.Errorf("expected value '%s' for key '%s' but got %t", testAttrs[key], key, attr.Value.AsBool())
+			}
+		}
+	}
+}
+
+func TestParseTime(t *testing.T) {
+	mustParse := func(layout, value string) time.Time {
+		out, err := time.Parse(layout, value)
+		if err != nil {
+			t.Fatalf("failed to parse time '%s' as format '%s': %s", value, layout, err)
+		}
+		return out
+	}
+
+	for _, testcase := range []struct {
+		name  string
+		input string
+		want  time.Time
+	}{
+		{
+			name:  "Unix epoch time without nanoseconds",
+			input: "1617739561", // date +%s
+			want:  time.Unix(1617739561, 0),
+		},
+		{
+			name:  "Unix epoch time with nanoseconds",
+			input: "1617739615.759793032", // date +%s.%N
+			want:  time.Unix(1617739615, 759793032),
+		},
+		{
+			name:  "RFC3339",
+			input: "2021-04-06T13:07:54Z",
+			want:  mustParse(time.RFC3339, "2021-04-06T13:07:54Z"),
+		},
+		{
+			name:  "RFC3339 with nanoseconds",
+			input: "2021-04-06T13:12:40.792426395Z",
+			want:  mustParse(time.RFC3339Nano, "2021-04-06T13:12:40.792426395Z"),
+		},
+		// date(1) RFC3339 format is incompatible with Go's formats
+		// so parseTime takes care of that automatically
+		{
+			name:  "date(1) RFC3339 output, with timezone",
+			input: "2021-04-06 13:07:54-07:00", //date --rfc-3339=seconds
+			want:  mustParse(time.RFC3339, "2021-04-06T13:07:54-07:00"),
+		},
+		{
+			name:  "date(1) RFC3339 with nanoseconds and timezone",
+			input: "2021-04-06 13:12:40.792426395-07:00", // date --rfc-3339=ns
+			want:  mustParse(time.RFC3339Nano, "2021-04-06T13:12:40.792426395-07:00"),
+		},
+		// TODO: maybe refactor parseTime to make failures easier to validate?
+		// @tobert: gonna leave that for functional tests for now
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			out := parseTime(testcase.input, "test")
+			if !out.Equal(testcase.want) {
+				t.Errorf("got wrong time from parseTime: %s", out.Format(time.RFC3339Nano))
+			}
+		})
+	}
+}
+
+func TestOtelSpanKind(t *testing.T) {
+
+	for _, testcase := range []struct {
+		name string
+		want trace.SpanKind
+	}{
+		{
+			name: "client",
+			want: trace.SpanKindClient,
+		},
+		{
+			name: "server",
+			want: trace.SpanKindServer,
+		},
+		{
+			name: "producer",
+			want: trace.SpanKindProducer,
+		},
+		{
+			name: "consumer",
+			want: trace.SpanKindConsumer,
+		},
+		{
+			name: "internal",
+			want: trace.SpanKindInternal,
+		},
+		{
+			name: "invalid",
+			want: trace.SpanKindUnspecified,
+		},
+		{
+			name: "speledwrong",
+			want: trace.SpanKindUnspecified,
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			out := otelSpanKind(testcase.name)
+			if out != testcase.want {
+				t.Errorf("otelSpanKind returned the wrong value, '%q', for '%s'", out, testcase.name)
+			}
+		})
+	}
+}
+
+func TestFinishOtelCliSpan(t *testing.T) {
+	// TODO: should this noop the tracing backend?
+
+	// set package globals to a known state
+	traceparentCarrierFile = ""
+	traceparentPrint = false
+	traceparentPrintExport = false
+
+	tp := "00-3433d5ae39bdfee397f44be5146867b3-8a5518f1e5c54d0a-01"
+	tid := "3433d5ae39bdfee397f44be5146867b3"
+	sid := "8a5518f1e5c54d0a"
+	os.Setenv("TRACEPARENT", tp)
+	tracer := otel.Tracer("testing/finishOtelCliSpan")
+	ctx, span := tracer.Start(context.Background(), "testing finishOtelCliSpan")
+
+	buf := new(bytes.Buffer)
+	// mostly smoke testing this, will validate printSpanData output
+	// TODO: maybe validate the file write works, but that's tested elsewhere...
+	finishOtelCliSpan(ctx, span, buf)
+	if buf.Len() != 0 {
+		t.Errorf("nothing was supposed to be written but %d bytes were", buf.Len())
+	}
+
+	traceparentPrint = true
+	traceparentPrintExport = true
+	buf = new(bytes.Buffer)
+	printSpanData(buf, tid, sid, tp)
+	if buf.Len() == 0 {
+		t.Error("expected more than zero bytes but got none")
+	}
+	expected := fmt.Sprintf("# trace id: %s\n#  span id: %s\nexport TRACEPARENT=%s\n", tid, sid, tp)
+	if buf.String() != expected {
+		t.Errorf("got unexpected output, expected '%s', got '%s'", expected, buf.String())
+	}
+}

--- a/cmd/otelclicarrier_test.go
+++ b/cmd/otelclicarrier_test.go
@@ -2,17 +2,145 @@ package cmd
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
 	"testing"
+
+	"go.opentelemetry.io/otel"
 )
 
-func TestLoadTraceparent(t *testing.T) {
-	file := "/dev/null"
-	ctx := context.Background()
+func TestOtelCliCarrier(t *testing.T) {
+	// make sure the environment variable isn't polluting test state
+	os.Unsetenv("TRACEPARENT")
 
-	// TODO:
-	//    * set env, see if it comes through
-	//    * set env and file, make sure the right one comes out
-	//    * clear env, set file, check
-	// etc
-	loadTraceparent(ctx, file)
+	carrier := NewOtelCliCarrier()
+	carrier.Clear() // clean up after other tests
+
+	// traceparent is the only key supported by OtelCliCarrier
+	got := carrier.Get("traceparent")
+	if got != "" {
+		t.Errorf("got a non-empty traceparent value '%s' where empty string was expected", got)
+	}
+
+	// foobar isn't supported but should be accepted and ignored silently
+	carrier.Set("foobar", "baz")
+	// if it shows up with any value whatsoever, something has gone wrong
+	if carrier.Get("foobar") != "" {
+		t.Errorf("got a non-empty key value where empty string was expected")
+	}
+
+	// traceparent is supported so this should work fine
+	tp := "00-b122b620341449410b9cd900c96d459d-aa21cda35388b694-01"
+	carrier.Set("traceparent", tp)
+
+	// even though 2 keys have been set at this point, the carrier only returns
+	// one key, traceparent
+	keys := carrier.Keys()
+	if len(keys) != 1 || keys[0] != "traceparent" {
+		t.Errorf("expected just one key from Keys() but instead got %q", keys)
+	}
+
+	// make sure the value round-trips in one piece
+	got = carrier.Get("traceparent")
+	if got != tp {
+		t.Errorf("expected traceparent value '%s' but got '%s'", tp, got)
+	}
+
+	// it's impractical to test the internal state of otel-go, so the next best
+	// thing is to round-trip our traceparent through it and make sure it comes
+	// back as expected
+	prop := otel.GetTextMapPropagator()
+	ctx := prop.Extract(context.Background(), carrier)
+	if ctx == nil {
+		t.Errorf("expected a context but got nil, likely a problem in otel? this shouldn't happen...")
+	}
+
+	// try to round trip the traceparent back out of that context ^^
+	rtCarrier := NewOtelCliCarrier()
+	prop.Inject(ctx, rtCarrier)
+	got = carrier.Get("traceparent")
+	if got != tp {
+		t.Errorf("round-tripping traceparent through a context failed, expected '%s', got '%s'", tp, got)
+	}
+
+	carrier.Clear() // clean up for other tests
+}
+
+func TestLoadTraceparent(t *testing.T) {
+	// make sure the environment variable isn't polluting test state
+	os.Unsetenv("TRACEPARENT")
+
+	// trace id should not change, because there's no envvar and no file
+	loadTraceparent(context.Background(), os.DevNull)
+	if envTp != "" {
+		t.Error("traceparent detected where there should be none")
+	}
+
+	// load from file only
+	testFileTp := "00-f61fc53f926e07a9c3893b1a722e1b65-7a2d6a804f3de137-01"
+	file, err := ioutil.TempFile(t.TempDir(), "go-test-otel-cli")
+	if err != nil {
+		t.Fatalf("unable to create tempfile for testing: %s", err)
+	}
+	defer os.Remove(file.Name())
+	// write in the full shell snippet format so that stripping gets tested
+	// in this pass too
+	file.WriteString("export TRACEPARENT=" + testFileTp)
+	file.Close()
+
+	// actually do the test...
+	fileCtx := loadTraceparent(context.Background(), file.Name())
+	got := getTraceparent(fileCtx)
+	if got != testFileTp {
+		t.Errorf("loadTraceparent with file failed, expected '%s', got '%s'", testFileTp, got)
+	}
+
+	// load from environment only
+	testEnvTp := "00-b122b620341449410b9cd900c96d459d-aa21cda35388b694-01"
+	os.Setenv("TRACEPARENT", testEnvTp)
+	envCtx := loadTraceparent(context.Background(), os.DevNull)
+	got = getTraceparent(envCtx)
+	if got != testEnvTp {
+		t.Errorf("loadTraceparent with envvar failed, expected '%s', got '%s'", testEnvTp, got)
+	}
+
+	// now try with both file and envvar set by the previous tests
+	// the file is expected to win
+	bothCtx := loadTraceparent(context.Background(), file.Name())
+	got = getTraceparent(bothCtx)
+	if got != testFileTp {
+		t.Errorf("loadTraceparent with file and envvar set to different values failed, expected '%s', got '%s'", testFileTp, got)
+	}
+}
+
+func TestWriteTraceparentToFile(t *testing.T) {
+	testTp := "00-ce1c6ae29edafc52eb6dd223da7d20b4-1c617f036253531c-01"
+
+	// create a tempfile for messing with
+	file, err := ioutil.TempFile(t.TempDir(), "go-test-otel-cli")
+	if err != nil {
+		t.Fatalf("unable to create tempfile for testing: %s", err)
+	}
+	file.Close()
+	defer os.Remove(file.Name()) // not strictly necessary
+
+	// set up a carrier and inject the traceparent
+	prop := otel.GetTextMapPropagator()
+	carrier := NewOtelCliCarrier()
+	carrier.Set("traceparent", testTp)
+	ctx := prop.Extract(context.Background(), carrier)
+
+	saveTraceparentToFile(ctx, file.Name())
+
+	// read the data back, it should just be the traceparent string
+	data, err := ioutil.ReadFile(file.Name())
+	if err != nil {
+		t.Fatalf("failed to read tempfile '%s': %s", file.Name(), err)
+	}
+	if len(data) == 0 {
+		t.Errorf("saveTraceparentToFile wrote %d bytes to the tempfile, expected %d", len(data), len(testTp))
+	}
+	if string(data) != testTp {
+		t.Errorf("invalid data in traceparent file, expected '%s', got '%s'", testTp, data)
+	}
 }

--- a/cmd/span.go
+++ b/cmd/span.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"os"
 	"regexp"
 
 	"github.com/spf13/cobra"
@@ -52,7 +53,7 @@ func doSpan(cmd *cobra.Command, args []string) {
 	ctx, span, shutdown := startSpan()
 	defer shutdown()
 	endSpan(span)
-	finishOtelCliSpan(ctx, span)
+	finishOtelCliSpan(ctx, span, os.Stdout)
 }
 
 // startSpan processes the optional --start option, starts a span, and returns a

--- a/cmd/span_background.go
+++ b/cmd/span_background.go
@@ -108,7 +108,7 @@ func doSpanBackground(cmd *cobra.Command, args []string) {
 	bgs.Run()
 
 	endSpan(span)
-	finishOtelCliSpan(ctx, span)
+	finishOtelCliSpan(ctx, span, os.Stdout)
 }
 
 func spanBgEndEvent(name string, span trace.Span) {

--- a/cmd/span_end.go
+++ b/cmd/span_end.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -36,5 +37,5 @@ func doSpanEnd(cmd *cobra.Command, args []string) {
 	}
 	shutdown()
 
-	printSpanData(res.TraceID, res.SpanID, res.Traceparent)
+	printSpanData(os.Stdout, res.TraceID, res.SpanID, res.Traceparent)
 }

--- a/cmd/span_event.go
+++ b/cmd/span_event.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"log"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -59,5 +60,5 @@ func doSpanEvent(cmd *cobra.Command, args []string) {
 		log.Fatalf("error while calling background server rpc BgSpan.AddEvent: %s", err)
 	}
 
-	printSpanData(res.TraceID, res.SpanID, res.Traceparent)
+	printSpanData(os.Stdout, res.TraceID, res.SpanID, res.Traceparent)
 }


### PR DESCRIPTION
While a lot of otel-cli is difficult or impractical to unit test, these two files contain functions that are testable. A couple things got updated to make the functions more testable along the way, and a bug got squashed.