### PR TITLE
make more things configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,26 @@ otel-cli span end --sockdir $sockdir
 kill %1
 ```
 
+## Configuration
+
+Everything is configurable via CLI arguments, and many of those arguments can
+also be configured via file or environment variables.
+
+| CLI argument    | environment variable          | config file key | example value  |
+| --------------- | ----------------------------- | --------------- | -------------- |
+| --endpoint      | OTEL_EXPORTER_OTLP_ENDPOINT   | endpoint        | localhost:4317 |
+| --insecure      | OTEL_EXPORTER_OTLP_INSECURE   | insecure        | false          |
+| --otlp-headers  | OTEL_EXPORTER_OTLP_HEADERS    | otlp-headers    | key=value      |
+| --otlp-blocking | OTEL_EXPORTER_OTLP_BLOCKING   | otlp-blocking   | false          |
+| --service       | OTEL_CLI_SERVICE_NAME         | service         | myapp          |
+| --kind          | OTEL_CLI_TRACE_KIND           | kind            | server         |
+| --attrs         | OTEL_CLI_ATTRIBUTES           | attrs           | k=v,a=b        |
+| --tp-required   | OTEL_CLI_TRACEPARENT_REQUIRED | tp-required     | false          |
+| --tp-carrier    | OTEL_CLI_CARRIER_FILE         | tp-carrier      | filename.txt   |
+| --tp-ignore-env | OTEL_CLI_IGNORE_ENV           | tp-ignore-env   | false          |
+| --tp-print      | OTEL_CLI_PRINT_TRACEPARENT    | tp-print        | false          |
+| --tp-export     | OTEL_CLI_EXPORT_TRACEPARENT   | tp-export       | false          |
+
 ## Easy local dev
 
 First, this needs some work to be good. Once the config plumbing is in
@@ -85,7 +105,7 @@ export HONEYCOMB_DATASET=playground # Honeycomb dataset
 
 docker run \
    --env LIGHTSTEP_TOKEN \
-   --env HONEYCOMB_DATASET \
+   --env HONEYCOMB_TEAM \
    --env HONEYCOMB_DATASET \
    --name otel-collector \
    --net host \

--- a/cmd/otelclicarrier.go
+++ b/cmd/otelclicarrier.go
@@ -63,7 +63,7 @@ func loadTraceparent(ctx context.Context, filename string) context.Context {
 	if filename != "" {
 		ctx = loadTraceparentFromFile(ctx, filename)
 	}
-	if traceparentCarrierRequired {
+	if traceparentRequired {
 		// TODO: find a better way to do this
 		// maybe check with the RE first?
 		tp := getTraceparent(ctx)       // get the text representation in the context
@@ -84,7 +84,7 @@ func loadTraceparentFromFile(ctx context.Context, filename string) context.Conte
 	if err != nil {
 		// only fatal when the tp carrier file is required explicitly, otherwise
 		// just silently return the unmodified context
-		if traceparentCarrierRequired {
+		if traceparentRequired {
 			log.Fatalf("could not open file '%s' for read: %s", filename, err)
 		} else {
 			return ctx

--- a/cmd/plumbing.go
+++ b/cmd/plumbing.go
@@ -3,6 +3,10 @@ package cmd
 import (
 	"context"
 	"log"
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp"
@@ -15,18 +19,25 @@ import (
 
 // initTracer sets up the OpenTelemetry plumbing so it's ready to use.
 // Returns a context and a func() that encapuslates clean shutdown.
+//
 func initTracer() (context.Context, func()) {
 	ctx := context.Background()
 
-	// TODO: make this configurable
-	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md
-	driver := otlpgrpc.NewDriver(
-		otlpgrpc.WithInsecure(),                  // TODO: make configurable
-		otlpgrpc.WithEndpoint("localhost:30080"), // TODO: make configurable
-	)
-	// ^^ examples usually show this with the grpc.WithBlock() dial option to make
+	driverOpts := []otlpgrpc.Option{otlpgrpc.WithEndpoint(otlpEndpoint)}
+
+	// gRPC does the right thing and forces us to say WithInsecure to disable encryption,
+	// but I expect most users of this program to point at a localhost endpoint that might not
+	// have any encryption available, or setting it up raises the bar of entry too high.
+	// The compromise is to automatically flip this flag to true when endpoint contains an
+	// an obvious "localhost", "127.0.0.x", or "::1" address.
+	if otlpInsecure || isLoopbackAddr(otlpEndpoint) {
+		driverOpts = append(driverOpts, otlpgrpc.WithInsecure())
+	}
+
+	// OTLP examples usually show this with the grpc.WithBlock() dial option to make
 	// the connection synchronous, but we don't want that and instead rely on
-	// the shutdown methods to make sure everything is done by the time we exit
+	// the shutdown methods to make sure everything is done by the time we exit.
+	driver := otlpgrpc.NewDriver(driverOpts...)
 
 	otlpExp, err := otlp.NewExporter(ctx, driver)
 	if err != nil {
@@ -69,4 +80,46 @@ func initTracer() (context.Context, func()) {
 			log.Fatalf("shutdown of OpenTelemetry OTLP exporter failed: %s", err)
 		}
 	}
+}
+
+// isLoopbackAddr takes a dial string, looks up the address, then returns true
+// if it points at either a v4 or v6 loopback address.
+// As I understood the OTLP spec, only host:port or an HTTP URL are acceptable.
+// This function is _not_ meant to validate the endpoint, that will happen when
+// otel-go attempts to connect to the endpoint as a gRPC dial address.
+func isLoopbackAddr(endpoint string) bool {
+	hpRe := regexp.MustCompile(`^[\w.-]+:\d+$`)
+	uriRe := regexp.MustCompile(`^(http|https)`)
+
+	endpoint = strings.TrimSpace(endpoint)
+
+	var hostname string
+	if hpRe.MatchString(endpoint) {
+		parts := strings.SplitN(endpoint, ":", 2)
+		hostname = parts[0]
+	} else if uriRe.MatchString(endpoint) {
+		u, err := url.Parse(endpoint)
+		if err != nil {
+			log.Fatalf("error parsing provided URI '%s': %s", endpoint, err)
+		}
+		hostname = u.Hostname()
+	} else {
+		log.Fatalf("'%s' is not a valid endpoint, must be host:port or a URI", endpoint)
+	}
+
+	ips, err := net.LookupIP(hostname)
+	if err != nil {
+		log.Fatalf("unable to look up hostname '%s': %s", hostname, err)
+	}
+
+	// all ips returned must be loopback to return true
+	// cases where that isn't true should be super rare, and probably all shenanigans
+	allAreLoopback := true
+	for _, ip := range ips {
+		if !ip.IsLoopback() {
+			allAreLoopback = false
+		}
+	}
+
+	return allAreLoopback
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,14 +1,18 @@
 package cmd
 
 import (
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // TODO: that's a lot of globals, maybe move this into a struct
-var serviceName, spanName, spanKind, traceparentCarrierFile string
+var cfgFile, serviceName, spanName, spanKind, traceparentCarrierFile string
 var spanAttrs map[string]string
+var otlpEndpoint string
+var otlpInsecure bool
 var traceparentIgnoreEnv, traceparentPrint, traceparentPrintExport bool
-var traceparentCarrierRequired bool
+var traceparentRequired bool
 var exitCode int
 
 // rootCmd represents the base command when called without any subcommands
@@ -26,22 +30,70 @@ func Execute() {
 
 func init() {
 	spanAttrs = make(map[string]string)
+	cobra.OnInitialize(initViperConfig)
 	cobra.EnableCommandSorting = false
 	rootCmd.Flags().SortFlags = false
 
-	// TODO: put in global flags for the otel endpoint and stuff like that here
-	rootCmd.PersistentFlags().StringVarP(&serviceName, "service", "n", "otel-cli", "set the name of the application sent on the traces")
+	// --config / -c a viper configuration file
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.otel-cli.yaml)")
 
-	// all commands and subcommands accept attributes, some might ignore
-	// e.g. `--attrs "foo=bar,baz=inga"`
-	rootCmd.PersistentFlags().StringToStringVarP(&spanAttrs, "attrs", "a", map[string]string{}, "a comma-separated list of key=value attributes")
+	// envvars are named according to the otel specs, others use the OTEL_CLI prefix
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md
+
+	rootCmd.PersistentFlags().StringVar(&otlpEndpoint, "endpoint", "localhost:4317", "dial address for the desired OTLP/gRPC endpoint")
+	viper.BindPFlag("endpoint", rootCmd.PersistentFlags().Lookup("endpoint"))
+	viper.BindEnv("OTEL_EXPORTER_OTLP_ENDPOINT", "endpoint")
+
+	rootCmd.PersistentFlags().BoolVar(&otlpInsecure, "insecure", false, "refuse to connect if TLS is unavailable (true by default when endpoint is localhost)")
+	viper.BindPFlag("insecure", rootCmd.PersistentFlags().Lookup("insecure"))
+	viper.BindEnv("OTEL_EXPORTER_OTLP_INSECURE", "insecure")
+
+	rootCmd.PersistentFlags().StringVarP(&serviceName, "service", "n", "otel-cli", "set the name of the application sent on the traces")
+	viper.BindPFlag("service", rootCmd.PersistentFlags().Lookup("service"))
+	viper.BindEnv("OTEL_CLI_SERVICE_NAME", "service")
 
 	rootCmd.PersistentFlags().StringVarP(&spanKind, "kind", "k", "client", "set the trace kind, e.g. internal, server, client, producer, consumer")
+	viper.BindPFlag("kind", rootCmd.PersistentFlags().Lookup("kind"))
+	viper.BindEnv("OTEL_CLI_TRACE_KIND", "kind")
+
+	rootCmd.PersistentFlags().StringToStringVarP(&spanAttrs, "attrs", "a", map[string]string{}, "a comma-separated list of key=value attributes")
+	viper.BindPFlag("attrs", rootCmd.PersistentFlags().Lookup("attrs"))
+	viper.BindEnv("OTEL_CLI_ATTRIBUTES", "attrs")
+
+	// trace propagation options
+	rootCmd.PersistentFlags().BoolVar(&traceparentRequired, "tp-required", false, "when set to true, fail and log if a traceparent can't be picked up from TRACEPARENT ennvar or a carrier file")
+	viper.BindPFlag("tp-required", rootCmd.PersistentFlags().Lookup("tp-required"))
+	viper.BindEnv("OTEL_CLI_TRACEPARENT_REQUIRED", "tp-required")
 
 	rootCmd.PersistentFlags().StringVar(&traceparentCarrierFile, "tp-carrier", "", "a file for reading and WRITING traceparent across invocations")
-	rootCmd.PersistentFlags().BoolVar(&traceparentCarrierRequired, "tp-carrier-required", false, "when set to true, fail and log when the carrier file doesn't already exist or TRACEPARENT isn't in the environment")
+	viper.BindPFlag("tp-carrier", rootCmd.PersistentFlags().Lookup("tp-carrier"))
+	viper.BindEnv("OTEL_CLI_CARRIER_FILE", "tp-carrier")
+
 	rootCmd.PersistentFlags().BoolVar(&traceparentIgnoreEnv, "tp-ignore-env", false, "ignore the TRACEPARENT envvar even if it's set")
+	viper.BindPFlag("tp-ignore-env", rootCmd.PersistentFlags().Lookup("tp-ignore-env"))
+	viper.BindEnv("OTEL_CLI_IGNORE_ENV", "tp-ignore-env")
+
 	rootCmd.PersistentFlags().BoolVar(&traceparentPrint, "tp-print", false, "print the trace id, span id, and the w3c-formatted traceparent representation of the new span")
-	// TOOD: probably remove this
+	viper.BindPFlag("tp-print", rootCmd.PersistentFlags().Lookup("tp-print"))
+	viper.BindEnv("OTEL_CLI_PRINT_TRACEPARENT", "tp-print")
+
 	rootCmd.PersistentFlags().BoolVarP(&traceparentPrintExport, "tp-export", "p", false, "same as --tp-print but it puts an 'export ' in front so it's more convinenient to source in scripts")
+	viper.BindPFlag("tp-export", rootCmd.PersistentFlags().Lookup("tp-export"))
+	viper.BindEnv("OTEL_CLI_EXPORT_TRACEPARENT", "tp-export")
+}
+
+func initViperConfig() {
+	if cfgFile != "" {
+		viper.SetConfigFile(cfgFile)
+	} else {
+		home, err := homedir.Dir()
+		cobra.CheckErr(err)
+
+		viper.AddConfigPath(home)
+		viper.SetConfigName(".otel-cli") // e.g. ~/.otel-cli.yaml
+	}
+
+	err := viper.ReadInConfig()
+	cobra.CheckErr(err)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,9 +8,9 @@ import (
 
 // TODO: that's a lot of globals, maybe move this into a struct
 var cfgFile, serviceName, spanName, spanKind, traceparentCarrierFile string
-var spanAttrs map[string]string
+var spanAttrs, otlpHeaders map[string]string
 var otlpEndpoint string
-var otlpInsecure bool
+var otlpInsecure, otlpBlocking bool
 var traceparentIgnoreEnv, traceparentPrint, traceparentPrintExport bool
 var traceparentRequired bool
 var exitCode int
@@ -30,6 +30,7 @@ func Execute() {
 
 func init() {
 	spanAttrs = make(map[string]string)
+	otlpHeaders = make(map[string]string)
 	cobra.OnInitialize(initViperConfig)
 	cobra.EnableCommandSorting = false
 	rootCmd.Flags().SortFlags = false
@@ -48,6 +49,14 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&otlpInsecure, "insecure", false, "refuse to connect if TLS is unavailable (true by default when endpoint is localhost)")
 	viper.BindPFlag("insecure", rootCmd.PersistentFlags().Lookup("insecure"))
 	viper.BindEnv("OTEL_EXPORTER_OTLP_INSECURE", "insecure")
+
+	rootCmd.PersistentFlags().StringToStringVar(&otlpHeaders, "otlp-headers", map[string]string{}, "a comma-sparated list of key=value headers to send on OTLP connection")
+	viper.BindPFlag("otlp-headers", rootCmd.PersistentFlags().Lookup("otlp-headers"))
+	viper.BindEnv("OTEL_EXPORTER_OTLP_HEADERS", "otlp-headers")
+
+	rootCmd.PersistentFlags().BoolVar(&otlpBlocking, "otlp-blocking", false, "block on connecting to the OTLP server before proceding")
+	viper.BindPFlag("otlp-blocking", rootCmd.PersistentFlags().Lookup("otlp-blocking"))
+	viper.BindEnv("OTEL_EXPORTER_OTLP_BLOCKING", "otlp-blocking")
 
 	rootCmd.PersistentFlags().StringVarP(&serviceName, "service", "n", "otel-cli", "set the name of the application sent on the traces")
 	viper.BindPFlag("service", rootCmd.PersistentFlags().Lookup("service"))

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/packethost/otel-cli
 go 1.14
 
 require (
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.1.3
+	github.com/spf13/viper v1.7.0
 	go.opentelemetry.io/otel v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp v0.19.0
 	go.opentelemetry.io/otel/sdk v0.19.0

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp v0.19.0
 	go.opentelemetry.io/otel/sdk v0.19.0
 	go.opentelemetry.io/otel/trace v0.19.0
+	google.golang.org/grpc v1.36.0
 )

--- a/local/otel-local-config.yaml
+++ b/local/otel-local-config.yaml
@@ -10,7 +10,7 @@ receivers:
     protocols:
       # OTLP over gRPC
       grpc:
-        endpoint: "0.0.0.0:30080"
+        endpoint: "0.0.0.0:4317"
       # OTLP over HTTP (opentelemetry-ruby only works on this proto for now)
       http:
         endpoint: "0.0.0.0:55681"


### PR DESCRIPTION
Adds a few new command-line options to configure OTLP endpoint, headers, and other behavior. Adds Viper bindings so the global config options can be configured in a file too. Adds environment variable configurations for most global options.