### PR TITLE
add demo, fix --tp-required and background propagation

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -86,5 +86,5 @@ func doExec(cmd *cobra.Command, args []string) {
 	// set the global exit code so main() can grab it and os.Exit() properly
 	exitCode = child.ProcessState.ExitCode()
 
-	finishOtelCliSpan(ctx, span, os.Stdout)
+	propagateOtelCliSpan(ctx, span, os.Stdout)
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -135,9 +135,9 @@ func GetExitCode() int {
 	return exitCode
 }
 
-// finishOtelCliSpan saves the traceparent to file if necessary, then prints
+// propagateOtelCliSpan saves the traceparent to file if necessary, then prints
 // span info to the console according to command-line args.
-func finishOtelCliSpan(ctx context.Context, span trace.Span, target io.Writer) {
+func propagateOtelCliSpan(ctx context.Context, span trace.Span, target io.Writer) {
 	saveTraceparentToFile(ctx, traceparentCarrierFile)
 
 	tpout := getTraceparent(ctx)

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -164,7 +164,7 @@ func TestOtelSpanKind(t *testing.T) {
 	}
 }
 
-func TestFinishOtelCliSpan(t *testing.T) {
+func TestPropagateOtelCliSpan(t *testing.T) {
 	// TODO: should this noop the tracing backend?
 
 	// set package globals to a known state
@@ -176,13 +176,13 @@ func TestFinishOtelCliSpan(t *testing.T) {
 	tid := "3433d5ae39bdfee397f44be5146867b3"
 	sid := "8a5518f1e5c54d0a"
 	os.Setenv("TRACEPARENT", tp)
-	tracer := otel.Tracer("testing/finishOtelCliSpan")
-	ctx, span := tracer.Start(context.Background(), "testing finishOtelCliSpan")
+	tracer := otel.Tracer("testing/propagateOtelCliSpan")
+	ctx, span := tracer.Start(context.Background(), "testing propagateOtelCliSpan")
 
 	buf := new(bytes.Buffer)
 	// mostly smoke testing this, will validate printSpanData output
 	// TODO: maybe validate the file write works, but that's tested elsewhere...
-	finishOtelCliSpan(ctx, span, buf)
+	propagateOtelCliSpan(ctx, span, buf)
 	if buf.Len() != 0 {
 		t.Errorf("nothing was supposed to be written but %d bytes were", buf.Len())
 	}

--- a/cmd/span.go
+++ b/cmd/span.go
@@ -53,7 +53,7 @@ func doSpan(cmd *cobra.Command, args []string) {
 	ctx, span, shutdown := startSpan()
 	defer shutdown()
 	endSpan(span)
-	finishOtelCliSpan(ctx, span, os.Stdout)
+	propagateOtelCliSpan(ctx, span, os.Stdout)
 }
 
 // startSpan processes the optional --start option, starts a span, and returns a

--- a/demos/15span-background-layered.sh
+++ b/demos/15span-background-layered.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# an otel-cli demo of span background
+#
+# This demo shows span background functionality with events added to the span
+# while it's running in the background, then a child span is created and
+# the background span is ended gracefully.
+
+set -e
+set -x
+
+carrier=$(mktemp)    # traceparent propagation via tempfile
+sockdir=$(mktemp -d) # a unix socket will be created here
+
+# start the span background server, set up trace propagation, and
+# time out after 10 seconds (which shouldn't be reached)
+../otel-cli span background \
+    --tp-carrier $carrier \
+    --sockdir $sockdir \
+    --tp-print \
+    --service $0 \
+    --name "$0 script execution" \
+    --timeout 10 &
+
+# TODO: figure out how to get rid of this, or make 'span event' block...
+sleep 0.1 # give span background 100ms to start up
+
+data1=$(uuidgen)
+
+# add an event to the span running in the background, with an attribute
+# set to the uuid we just generated
+../otel-cli span event \
+    --name "did a thing" \
+    --sockdir $sockdir \
+    --attrs "data1=$data1"
+
+# waste some time
+sleep 1
+
+# add an event that says we wasted some time
+../otel-cli span event --name "slept 1 second" --sockdir $sockdir
+
+# run a shorter sleep inside a child span, also note that this is using
+# --tp-required so this will fail loudly if there is no traceparent
+# available
+../otel-cli exec \
+    --service $0 \
+    --name "sleep 0.2" \
+    --tp-required \
+    --tp-carrier $carrier \
+    --tp-print \
+    sleep 0.2
+
+# finally, tell the background server we're all done and it can exit
+../otel-cli span end --sockdir $sockdir
+


### PR DESCRIPTION
While writing the newest demo I found a couple bugs.

1.) --tp-required paniced, so I took care of the TODO and made that code
  a little more robust
2.) span background was waiting until the end to propagate the span but
  that's not what we want, so now it does that as soon as there's a span

Also renamed finishOtelCliSpan to propagateOtelCliSpan which is more
accurate, since it does not end the span and does not need to be at the
end of the chain.