### PR TITLE
poll and wait for the background socket

### DIFF
--- a/cmd/span_end.go
+++ b/cmd/span_end.go
@@ -23,6 +23,7 @@ See: otel-cli span background
 func init() {
 	spanCmd.AddCommand(spanEndCmd)
 	spanEndCmd.Flags().StringVar(&spanBgSockdir, "sockdir", "", "a directory where a socket can be placed safely")
+	spanEndCmd.Flags().IntVar(&spanBgTimeout, "timeout", 5, "how long to wait for the background server socket to be available")
 	spanEndCmd.MarkFlagRequired("sockdir")
 }
 

--- a/cmd/span_event.go
+++ b/cmd/span_event.go
@@ -33,13 +33,9 @@ func init() {
 	spanCmd.AddCommand(spanEventCmd)
 	spanEventCmd.Flags().SortFlags = false
 
-	// --name / -n
 	spanEventCmd.Flags().StringVarP(&spanEventName, "name", "e", "todo-generate-default-event-names", "set the name of the event")
-
-	// --time / -t
 	spanEventCmd.Flags().StringVarP(&spanEventTime, "time", "t", "now", "the precise time of the event in RFC3339Nano or Unix.nano format")
-
-	// --sockdir
+	spanEventCmd.Flags().IntVar(&spanBgTimeout, "timeout", 5, "how long to wait for the background server socket to be available")
 	spanEventCmd.Flags().StringVar(&spanBgSockdir, "sockdir", "", "a directory where a socket can be placed safely")
 	spanEventCmd.MarkFlagRequired("sockdir")
 }

--- a/demos/15span-background-layered.sh
+++ b/demos/15span-background-layered.sh
@@ -21,9 +21,6 @@ sockdir=$(mktemp -d) # a unix socket will be created here
     --name "$0 script execution" \
     --timeout 10 &
 
-# TODO: figure out how to get rid of this, or make 'span event' block...
-sleep 0.1 # give span background 100ms to start up
-
 data1=$(uuidgen)
 
 # add an event to the span running in the background, with an attribute


### PR DESCRIPTION
This gets rid of needing to sleep after putting the span background
service in a background process. Previous to this change there was an
easy race where the server would still be starting up by the time the
calling script tried its first event. This makes the clients wait for
that socket to show up, up to a timeout.