### PR TITLE
Allow the config file to be optional

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,6 +105,12 @@ func initViperConfig() {
 		viper.SetConfigName(".otel-cli") // e.g. ~/.otel-cli.yaml
 	}
 
-	err := viper.ReadInConfig()
-	cobra.CheckErr(err)
+	if err := viper.ReadInConfig(); err != nil {
+		// We want to suppress errors here if the config is not found, but only if the user has not expressly given us a location to search.
+		// Otherwise, we'll raise any config-reading error up to the user.
+		_, cfgNotFound := err.(viper.ConfigFileNotFoundError)
+		if cfgFile != "" || !cfgNotFound {
+			cobra.CheckErr(err)
+		}
+	}
 }


### PR DESCRIPTION
`cobra.CheckErr(err)` raised an error the first time I tried to run it:

```
~/projects/otel-cli main*
❯ ./otel-cli exec -n my-cool-thing -s interesting-step echo 'hello'
Error: Config File ".otel-cli" Not Found in "[/Users/ahayworth]"

~/projects/otel-cli main*
❯ echo $?
1
```

To fix, we change the logic slightly:
- If the user has supplied a config file, we'll unconditionally check the error (any actual error is probably a real error!)
- If the user has not supplied a config file, and the error is simply "I cannot find a config file", we ignore the error.