### PR TITLE
fix: enable TLS on secure connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ also be configured via file or environment variables.
 | --tp-ignore-env | OTEL_CLI_IGNORE_ENV           | tp-ignore-env   | false          |
 | --tp-print      | OTEL_CLI_PRINT_TRACEPARENT    | tp-print        | false          |
 | --tp-export     | OTEL_CLI_EXPORT_TRACEPARENT   | tp-export       | false          |
+| --no-tls-verify | OTEL_CLI_NO_TLS_VERIFY        | no-tls-verify   | false          |
 
 ## Easy local dev
 

--- a/cmd/plumbing.go
+++ b/cmd/plumbing.go
@@ -39,6 +39,11 @@ func initTracer() (context.Context, func()) {
 		driverOpts = append(driverOpts, otlpgrpc.WithInsecure())
 	} else {
 		var config *tls.Config
+		if noTlsVerify {
+			config = &tls.Config{
+				InsecureSkipVerify: true,
+			}
+		}
 		driverOpts = append(driverOpts, otlpgrpc.WithDialOption(grpc.WithTransportCredentials(credentials.NewTLS(config))))
 	}
 

--- a/cmd/plumbing.go
+++ b/cmd/plumbing.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"crypto/tls"
 	"log"
 	"net"
 	"net/url"
@@ -18,6 +19,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/semconv"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 // initTracer sets up the OpenTelemetry plumbing so it's ready to use.
@@ -35,6 +37,9 @@ func initTracer() (context.Context, func()) {
 	// an obvious "localhost", "127.0.0.x", or "::1" address.
 	if otlpInsecure || isLoopbackAddr(otlpEndpoint) {
 		driverOpts = append(driverOpts, otlpgrpc.WithInsecure())
+	} else {
+		var config *tls.Config
+		driverOpts = append(driverOpts, otlpgrpc.WithDialOption(grpc.WithTransportCredentials(credentials.NewTLS(config))))
 	}
 
 	// support for OTLP headers, e.g. for authenticating to SaaS OTLP endpoints

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 var cfgFile, serviceName, spanName, spanKind, traceparentCarrierFile string
 var spanAttrs, otlpHeaders map[string]string
 var otlpEndpoint string
-var otlpInsecure, otlpBlocking bool
+var otlpInsecure, otlpBlocking, noTlsVerify bool
 var traceparentIgnoreEnv, traceparentPrint, traceparentPrintExport bool
 var traceparentRequired, testMode bool
 var exitCode int
@@ -90,6 +90,10 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&traceparentPrintExport, "tp-export", "p", false, "same as --tp-print but it puts an 'export ' in front so it's more convinenient to source in scripts")
 	viper.BindPFlag("tp-export", rootCmd.PersistentFlags().Lookup("tp-export"))
 	viper.BindEnv("OTEL_CLI_EXPORT_TRACEPARENT", "tp-export")
+
+	rootCmd.PersistentFlags().BoolVar(&noTlsVerify, "no-tls-verify", false, "enable it when TLS is enabled and you want to ignore the certificate validation. This is common when you are testing and usign self-seigned certificates.")
+	viper.BindPFlag("no-tls-verify", rootCmd.PersistentFlags().Lookup("no-tls-verify"))
+	viper.BindEnv("OTEL_CLI_NO_TLS_VERIFY", "no-tls-verify")
 
 	rootCmd.PersistentFlags().BoolVar(&testMode, "test", false, "configure noop exporter and dump data to json on stdout instead of sending")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,7 +91,7 @@ func init() {
 	viper.BindPFlag("tp-export", rootCmd.PersistentFlags().Lookup("tp-export"))
 	viper.BindEnv("OTEL_CLI_EXPORT_TRACEPARENT", "tp-export")
 
-	rootCmd.PersistentFlags().BoolVar(&noTlsVerify, "no-tls-verify", false, "enable it when TLS is enabled and you want to ignore the certificate validation. This is common when you are testing and usign self-seigned certificates.")
+	rootCmd.PersistentFlags().BoolVar(&noTlsVerify, "no-tls-verify", false, "enable it when TLS is enabled and you want to ignore the certificate validation. This is common when you are testing and usign self-signed certificates.")
 	viper.BindPFlag("no-tls-verify", rootCmd.PersistentFlags().Lookup("no-tls-verify"))
 	viper.BindEnv("OTEL_CLI_NO_TLS_VERIFY", "no-tls-verify")
 


### PR DESCRIPTION
Testing the otel-cli against a service exposed with `https`, we detected that the connection is closed. The current PR adds the dial option to negotiate an `https` connection in case you connect to a remote endpoint and you do not set `--insecure=true` flag.

