### PR TITLE
fix bug that prevents timeout from working

### DIFF
--- a/cmd/server_json.go
+++ b/cmd/server_json.go
@@ -39,7 +39,6 @@ func init() {
 func doServerJson(cmd *cobra.Command, args []string) {
 	stop := func(cs *cliServer) {}
 	cs := newServer(renderJson, stop)
-	cs.ServeGPRC()
 
 	// stops the grpc server after timeout
 	if jsonSvr.timeout > 0 {
@@ -48,6 +47,8 @@ func doServerJson(cmd *cobra.Command, args []string) {
 			cs.stopper <- true
 		}()
 	}
+
+	cs.ServeGPRC()
 }
 
 // writeFile takes the spans and events and writes them out to json files in the


### PR DESCRIPTION
Found this while writing tests for another project that uses otel-cli.

My bad. When this other testing project is about done I will implement a similar strategy for otel-cli.